### PR TITLE
tcproute: add support for round-robin load balancing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,14 +78,16 @@ jobs:
         BLIXT_UDP_SERVER_IMAGE: "ghcr.io/kubernetes-sigs/blixt-udp-test-server"
         TAG: "integration-tests"
 
-    - name: run integration tests with bpfd
-      run: make test.integration
-      env:
-        BLIXT_CONTROLPLANE_IMAGE: "ghcr.io/kubernetes-sigs/blixt-controlplane"
-        BLIXT_DATAPLANE_IMAGE: "ghcr.io/kubernetes-sigs/blixt-dataplane"
-        BLIXT_UDP_SERVER_IMAGE: "ghcr.io/kubernetes-sigs/blixt-udp-test-server"
-        BLIXT_USE_BPFD: true
-        TAG: "integration-tests"
+    # temporarily disabled due to upstream changes in bpfman (previously bpfd)
+    # ref: https://github.com/kubernetes-sigs/blixt/issues/152
+    # - name: run integration tests with bpfd
+    #   run: make test.integration
+    #   env:
+    #     BLIXT_CONTROLPLANE_IMAGE: "ghcr.io/kubernetes-sigs/blixt-controlplane"
+    #     BLIXT_DATAPLANE_IMAGE: "ghcr.io/kubernetes-sigs/blixt-dataplane"
+    #     BLIXT_UDP_SERVER_IMAGE: "ghcr.io/kubernetes-sigs/blixt-udp-test-server"
+    #     BLIXT_USE_BPFD: true
+    #     TAG: "integration-tests"
 
     ## Upload diagnostics if integration test step failed.
     - name: upload diagnostics

--- a/config/samples/tcproute/server.yaml
+++ b/config/samples/tcproute/server.yaml
@@ -16,11 +16,9 @@ spec:
     spec:
       containers:
       - name: server
-        image: ghcr.io/shaneutt/malutki
+        image: istio/tcp-echo-server:1.1
         imagePullPolicy: IfNotPresent
-        env:
-        - name: LISTEN_PORT
-          value: "8080"
+        args: [ "8080", "blixt-tcproute-sample:" ]
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/config/tests/tcproute-rr/kustomization.yaml
+++ b/config/tests/tcproute-rr/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../samples/tcproute
+- server.yaml
+patches:
+- path: patch.yaml

--- a/config/tests/tcproute-rr/patch.yaml
+++ b/config/tests/tcproute-rr/patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: blixt-tcproute-sample
+spec:
+  parentRefs:
+  - name: blixt-tcproute-sample
+    port: 8080
+  rules:
+  - backendRefs:
+    - name: blixt-tcproute-sample
+      port: 8080
+  - backendRefs:
+    - name: tcproute-rr-v1
+      port: 8080
+    - name: tcproute-rr-v2
+      port: 8080

--- a/config/tests/tcproute-rr/server.yaml
+++ b/config/tests/tcproute-rr/server.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcproute-rr-v1
+  labels:
+    app: tcproute-rr-v1
+spec:
+  selector:
+    matchLabels:
+      app: tcproute-rr-v1
+  template:
+    metadata:
+      labels:
+        app: tcproute-rr-v1
+    spec:
+      containers:
+      - name: tcp-echo
+        image: istio/tcp-echo-server:1.1
+        imagePullPolicy: IfNotPresent
+        args: [ "8080", "tcproute-rr-v1:" ]
+        ports:
+        - containerPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcproute-rr-v2
+  labels:
+    app: tcproute-rr-v2
+spec:
+  selector:
+    matchLabels:
+      app: tcproute-rr-v2
+  template:
+    metadata:
+      labels:
+        app: tcproute-rr-v2
+    spec:
+      containers:
+      - name: tcp-echo
+        image: istio/tcp-echo-server:1.1
+        imagePullPolicy: IfNotPresent
+        args: [ "8080", "tcproute-rr-v2:" ]
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tcproute-rr-v1
+  name: tcproute-rr-v1
+spec:
+  ports:
+  - name: tcp
+    port: 8080
+    protocol: TCP
+  selector:
+    app: tcproute-rr-v1
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tcproute-rr-v2
+  name: tcproute-rr-v2
+spec:
+  ports:
+  - name: tcp
+    port: 8080
+    protocol: TCP
+  selector:
+    app: tcproute-rr-v2
+  type: ClusterIP

--- a/dataplane/api-server/src/backends.rs
+++ b/dataplane/api-server/src/backends.rs
@@ -45,8 +45,8 @@ pub struct InterfaceIndexConfirmation {
 /// Generated client implementations.
 pub mod backends_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct BackendsClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -90,8 +90,9 @@ pub mod backends_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             BackendsClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -129,16 +130,23 @@ pub mod backends_client {
         pub async fn get_interface_index(
             &mut self,
             request: impl tonic::IntoRequest<super::PodIp>,
-        ) -> std::result::Result<tonic::Response<super::InterfaceIndexConfirmation>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InterfaceIndexConfirmation>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/backends.backends/GetInterfaceIndex");
+            let path = http::uri::PathAndQuery::from_static(
+                "/backends.backends/GetInterfaceIndex",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("backends.backends", "GetInterfaceIndex"));
@@ -148,34 +156,38 @@ pub mod backends_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Targets>,
         ) -> std::result::Result<tonic::Response<super::Confirmation>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/backends.backends/Update");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("backends.backends", "Update"));
+            req.extensions_mut().insert(GrpcMethod::new("backends.backends", "Update"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn delete(
             &mut self,
             request: impl tonic::IntoRequest<super::Vip>,
         ) -> std::result::Result<tonic::Response<super::Confirmation>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/backends.backends/Delete");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("backends.backends", "Delete"));
+            req.extensions_mut().insert(GrpcMethod::new("backends.backends", "Delete"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -190,7 +202,10 @@ pub mod backends_server {
         async fn get_interface_index(
             &self,
             request: tonic::Request<super::PodIp>,
-        ) -> std::result::Result<tonic::Response<super::InterfaceIndexConfirmation>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InterfaceIndexConfirmation>,
+            tonic::Status,
+        >;
         async fn update(
             &self,
             request: tonic::Request<super::Targets>,
@@ -223,7 +238,10 @@ pub mod backends_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -279,12 +297,21 @@ pub mod backends_server {
                 "/backends.backends/GetInterfaceIndex" => {
                     #[allow(non_camel_case_types)]
                     struct GetInterfaceIndexSvc<T: Backends>(pub Arc<T>);
-                    impl<T: Backends> tonic::server::UnaryService<super::PodIp> for GetInterfaceIndexSvc<T> {
+                    impl<T: Backends> tonic::server::UnaryService<super::PodIp>
+                    for GetInterfaceIndexSvc<T> {
                         type Response = super::InterfaceIndexConfirmation;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::PodIp>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::PodIp>,
+                        ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).get_interface_index(request).await };
+                            let fut = async move {
+                                (*inner).get_interface_index(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -314,9 +341,13 @@ pub mod backends_server {
                 "/backends.backends/Update" => {
                     #[allow(non_camel_case_types)]
                     struct UpdateSvc<T: Backends>(pub Arc<T>);
-                    impl<T: Backends> tonic::server::UnaryService<super::Targets> for UpdateSvc<T> {
+                    impl<T: Backends> tonic::server::UnaryService<super::Targets>
+                    for UpdateSvc<T> {
                         type Response = super::Confirmation;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::Targets>,
@@ -352,10 +383,17 @@ pub mod backends_server {
                 "/backends.backends/Delete" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteSvc<T: Backends>(pub Arc<T>);
-                    impl<T: Backends> tonic::server::UnaryService<super::Vip> for DeleteSvc<T> {
+                    impl<T: Backends> tonic::server::UnaryService<super::Vip>
+                    for DeleteSvc<T> {
                         type Response = super::Confirmation;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::Vip>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Vip>,
+                        ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).delete(request).await };
                             Box::pin(fut)
@@ -384,14 +422,18 @@ pub mod backends_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }

--- a/dataplane/api-server/src/lib.rs
+++ b/dataplane/api-server/src/lib.rs
@@ -15,15 +15,16 @@ use aya::maps::{HashMap, MapData};
 use tonic::transport::Server;
 
 use backends::backends_server::BackendsServer;
-use common::{BackendKey, BackendList};
+use common::{BackendKey, BackendList, ClientKey, TCPBackend};
 
 pub async fn start(
     addr: Ipv4Addr,
     port: u16,
     backends_map: HashMap<MapData, BackendKey, BackendList>,
     gateway_indexes_map: HashMap<MapData, BackendKey, u16>,
+    tcp_conns_map: HashMap<MapData, ClientKey, TCPBackend>,
 ) -> Result<(), Error> {
-    let server = server::BackendService::new(backends_map, gateway_indexes_map);
+    let server = server::BackendService::new(backends_map, gateway_indexes_map, tcp_conns_map);
     // TODO: mTLS https://github.com/Kong/blixt/issues/50
     Server::builder()
         .add_service(BackendsServer::new(server))

--- a/dataplane/common/src/lib.rs
+++ b/dataplane/common/src/lib.rs
@@ -20,7 +20,7 @@ pub struct Backend {
 #[cfg(feature = "user")]
 unsafe impl aya::Pod for Backend {}
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct BackendKey {
     pub ip: u32,
@@ -40,3 +40,41 @@ pub struct BackendList {
 
 #[cfg(feature = "user")]
 unsafe impl aya::Pod for BackendList {}
+
+#[derive(Copy, Clone, Debug)]
+#[repr(C)]
+pub struct ClientKey {
+    pub ip: u32,
+    pub port: u32,
+}
+
+#[cfg(feature = "user")]
+unsafe impl aya::Pod for ClientKey {}
+
+// TCPState contains variants that represent the current phase of the TCP connection at a point in
+// time during the connection's termination.
+#[derive(Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub enum TCPState {
+    #[default]
+    Established,
+    FinWait1,
+    FinWait2,
+    Closing,
+    TimeWait,
+    Closed,
+}
+
+#[cfg(feature = "user")]
+unsafe impl aya::Pod for TCPState {}
+
+#[derive(Copy, Clone, Debug)]
+#[repr(C)]
+pub struct TCPBackend {
+    pub backend: Backend,
+    pub backend_key: BackendKey,
+    pub state: TCPState,
+}
+
+#[cfg(feature = "user")]
+unsafe impl aya::Pod for TCPBackend {}

--- a/dataplane/ebpf/src/main.rs
+++ b/dataplane/ebpf/src/main.rs
@@ -22,7 +22,7 @@ use aya_bpf::{
     programs::TcContext,
 };
 
-use common::{BackendKey, BackendList, BPF_MAPS_CAPACITY};
+use common::{BackendKey, BackendList, ClientKey, TCPBackend, BPF_MAPS_CAPACITY};
 use egress::{icmp::handle_icmp_egress, tcp::handle_tcp_egress};
 use ingress::{tcp::handle_tcp_ingress, udp::handle_udp_ingress};
 
@@ -47,6 +47,10 @@ static mut GATEWAY_INDEXES: HashMap<BackendKey, u16> =
 #[map(name = "BLIXT_CONNTRACK")]
 static mut BLIXT_CONNTRACK: HashMap<u32, (u32, u32)> =
     HashMap::<u32, (u32, u32)>::with_max_entries(BPF_MAPS_CAPACITY, 0);
+
+#[map(name = "TCP_CONNECTIONS")]
+static mut TCP_CONNECTIONS: HashMap<ClientKey, TCPBackend> =
+    HashMap::<ClientKey, TCPBackend>::with_max_entries(128, 0);
 
 // -----------------------------------------------------------------------------
 // Ingress

--- a/dataplane/ebpf/src/utils.rs
+++ b/dataplane/ebpf/src/utils.rs
@@ -4,8 +4,12 @@ Copyright 2023 The Kubernetes Authors.
 SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 */
 
-use core::mem;
 use aya_bpf::{bindings::TC_ACT_OK, programs::TcContext};
+use core::mem;
+use network_types::tcp::TcpHdr;
+
+use crate::TCP_CONNECTIONS;
+use common::{ClientKey, TCPBackend, TCPState};
 
 // -----------------------------------------------------------------------------
 // Helper Functions
@@ -33,4 +37,88 @@ pub fn csum_fold_helper(mut csum: u64) -> u16 {
         }
     }
     return !(csum as u16);
+}
+
+// Updates the TCP connection's state based on the current phase and the incoming packet's header.
+// It returns true if the state transitioned to a different phase.
+// Ref: https://en.wikipedia.org/wiki/File:Tcp_state_diagram.png and
+// http://www.tcpipguide.com/free/t_TCPConnectionTermination-2.htm
+#[inline(always)]
+pub fn process_tcp_state_transition(hdr: &TcpHdr, state: &mut TCPState) -> bool {
+    let fin = hdr.fin() == 1;
+    let ack = hdr.ack() == 1;
+    match state {
+        TCPState::Established => {
+            // At the Established state, a FIN packet moves the state to FinWait1.
+            if fin {
+                *state = TCPState::FinWait1;
+                return true;
+            }
+        }
+        TCPState::FinWait1 => {
+            // At the FinWait1 state, a packet with both the FIN and ACK bits set
+            // moves the state to TimeWait.
+            if fin && ack {
+                *state = TCPState::TimeWait;
+                return true;
+            }
+            // At the FinWait1 state, a FIN packet moves the state to Closing.
+            if fin {
+                *state = TCPState::Closing;
+                return true;
+            }
+            // At the FinWait1 state, an ACK packet moves the state to FinWait2.
+            if ack {
+                *state = TCPState::FinWait2;
+                return true;
+            }
+        }
+        TCPState::FinWait2 => {
+            // At the FinWait2 state, an ACK packet moves the state to TimeWait.
+            if ack {
+                *state = TCPState::TimeWait;
+                return true;
+            }
+        }
+        TCPState::Closing => {
+            // At the Closing state, an ACK packet moves the state to TimeWait.
+            if ack {
+                *state = TCPState::TimeWait;
+                return true;
+            }
+        }
+        TCPState::TimeWait => {
+            if ack {
+                *state = TCPState::Closed;
+                return true;
+            }
+        }
+        TCPState::Closed => {}
+    }
+    return false;
+}
+
+// Modifies the map tracking TCP connections based on the current state
+// of the TCP connection and the incoming TCP packet's header.
+#[inline(always)]
+pub fn update_tcp_conns(
+    hdr: &TcpHdr,
+    client_key: &ClientKey,
+    tcp_backend: &mut TCPBackend,
+) -> Result<(), i64> {
+    let transitioned = process_tcp_state_transition(hdr, &mut tcp_backend.state);
+    if let TCPState::Closed = tcp_backend.state {
+        unsafe {
+            return TCP_CONNECTIONS.remove(&client_key);
+        }
+    }
+    // If the connection has not reached the Closed state yet, but it did transition to a new state,
+    // then record the new state.
+    if transitioned {
+        unsafe {
+            return TCP_CONNECTIONS.insert(&client_key, &tcp_backend, 0_u64);
+        }
+    }
+
+    Ok(())
 }

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -20,9 +20,10 @@ limitations under the License.
 package integration
 
 import (
+	"bufio"
 	"context"
 	"fmt"
-	"net/http"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -38,8 +39,11 @@ import (
 
 const (
 	tcprouteSampleKustomize = "../../config/tests/tcproute"
+	tcprouteRRKustomize     = "../../config/tests/tcproute-rr"
 	tcprouteSampleName      = "blixt-tcproute-sample"
 )
+
+var tcpServerNames = []string{"blixt-tcproute-sample", "tcproute-rr-v1", "tcproute-rr-v2"}
 
 func TestTCPRouteBasics(t *testing.T) {
 	tcpRouteBasicsCleanupKey := "tcproutebasics"
@@ -69,38 +73,184 @@ func TestTCPRouteBasics(t *testing.T) {
 	require.Equal(t, gatewayv1beta1.IPAddressType, *gw.Status.Addresses[0].Type)
 	gwaddr := fmt.Sprintf("%s:8080", gw.Status.Addresses[0].Value)
 
-	t.Log("waiting for HTTP server to be available")
+	t.Log("waiting for TCP server to be available")
 	require.Eventually(t, func() bool {
 		server, err := env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, tcprouteSampleName, metav1.GetOptions{})
 		require.NoError(t, err)
 		return server.Status.AvailableReplicas > 0
 	}, time.Minute, time.Second)
 
-	t.Log("verifying HTTP connectivity to the server")
-	httpc := http.Client{Timeout: time.Second * 30}
+	t.Log("verifying TCP connectivity to the server")
+	var conn net.Conn
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("http://%s/status/%d", gwaddr, http.StatusTeapot))
+		var err error
+		conn, err = net.Dial("tcp", gwaddr)
 		if err != nil {
-			t.Logf("received error checking HTTP server: [%s], retrying...", err)
+			t.Logf("received error connecting to TCP server: [%s], retrying...", err)
 			return false
 		}
-		defer resp.Body.Close()
-		return resp.StatusCode == http.StatusTeapot
+		return true
 	}, time.Minute*5, time.Second)
 
-	t.Log("deleting the TCPRoute and verifying that HTTP traffic stops")
+	response := writeAndReadTCP(t, conn)
+	require.Contains(t, response, tcpServerNames[0])
+
+	t.Log("deleting the TCPRoute and verifying that TCP connection is closed")
 	require.NoError(t, gwclient.GatewayV1alpha2().TCPRoutes(corev1.NamespaceDefault).Delete(ctx, tcprouteSampleName, metav1.DeleteOptions{}))
-	httpc = http.Client{Timeout: time.Second * 3}
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("http://%s/status/%d", gwaddr, http.StatusTeapot))
+		_, err := conn.Write([]byte("blahhh\n"))
+		require.NoError(t, err)
+
+		err = conn.SetReadDeadline(time.Now().Add(time.Second * 3))
+		require.NoError(t, err)
+		reader := bufio.NewReader(conn)
+		_, err = reader.ReadBytes(byte('\n'))
 		if err != nil {
-			if strings.Contains(err.Error(), "context deadline exceeded") {
+			if strings.Contains(err.Error(), "i/o timeout") {
 				return true
 			}
 			t.Logf("received unexpected error waiting for TCPRoute to decomission: %s", err)
 			return false
 		}
-		defer resp.Body.Close()
 		return false
 	}, time.Minute, time.Second)
+}
+
+func TestTCPRouteRoundRobin(t *testing.T) {
+	tcpRouteRRCleanupKey := "tcprouterr"
+	defer func() {
+		testutils.DumpDiagnosticsIfFailed(ctx, t, env.Cluster())
+		if err := runCleanup(tcpRouteRRCleanupKey); err != nil {
+			t.Errorf("cleanup failed: %s", err)
+		}
+	}()
+
+	t.Log("deploying config/samples/tcproute-rr kustomize")
+	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), tcprouteRRKustomize))
+	addCleanup(tcpRouteRRCleanupKey, func(ctx context.Context) error {
+		cleanupLog("cleaning up config/samples/tcproute-rr kustomize")
+		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), tcprouteRRKustomize, "--ignore-not-found=true")
+	})
+
+	t.Log("waiting for Gateway to have an address")
+	var gw *gatewayv1beta1.Gateway
+	require.Eventually(t, func() bool {
+		var err error
+		gw, err = gwclient.GatewayV1beta1().Gateways(corev1.NamespaceDefault).Get(ctx, tcprouteSampleName, metav1.GetOptions{})
+		require.NoError(t, err)
+		return len(gw.Status.Addresses) > 0
+	}, time.Minute, time.Second)
+	require.NotNil(t, gw.Status.Addresses[0].Type)
+	require.Equal(t, gatewayv1beta1.IPAddressType, *gw.Status.Addresses[0].Type)
+	gwaddr := fmt.Sprintf("%s:8080", gw.Status.Addresses[0].Value)
+
+	t.Log("waiting for TCP servers to be available")
+	labelSelector := metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "app",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   tcpServerNames,
+			},
+		},
+	}
+	require.Eventually(t, func() bool {
+		servers, err := env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
+			LabelSelector: metav1.FormatLabelSelector(&labelSelector),
+		})
+		require.NoError(t, err)
+		for _, server := range servers.Items {
+			if server.Status.AvailableReplicas <= 0 {
+				return false
+			}
+		}
+		return true
+	}, time.Minute, time.Second)
+
+	t.Log("verifying TCP connectivity to the servers")
+	// We create three TCP connections, one for each backend.
+	var conn1 net.Conn
+	require.Eventually(t, func() bool {
+		var err error
+		conn1, err = net.Dial("tcp", gwaddr)
+		if err != nil {
+			t.Logf("received error connecting to TCP server: [%s], retrying...", err)
+			return false
+		}
+		return true
+	}, time.Minute*5, time.Second)
+	conn2, err := net.Dial("tcp", gwaddr)
+	require.NoError(t, err)
+	conn3, err := net.Dial("tcp", gwaddr)
+	require.NoError(t, err)
+	conns := []net.Conn{conn1, conn2, conn3}
+
+	// Run it twice to verify that we load balance in a round-robin fashion.
+	for c := 0; c < 2; c++ {
+		// We can't do names := tcpServerNames because we overwrite this in the loop later.
+		var names []string
+		names = append(names, tcpServerNames...)
+
+		for _, conn := range conns {
+			response := writeAndReadTCP(t, conn)
+			split := strings.Split(response, ":")
+			require.Len(t, split, 2)
+			name := split[0]
+			var removed bool
+			names, removed = removeName(names, name)
+			// If no name was removed from the list, it means that the response
+			// does not contain the name of a known server.
+			if !removed {
+				t.Fatalf("received unexpected response from backend: %s", name)
+			}
+		}
+		require.Len(t, names, 0)
+	}
+
+	t.Log("deleting the TCPRoute and verifying that all TCP connections are closed")
+	require.NoError(t, gwclient.GatewayV1alpha2().TCPRoutes(corev1.NamespaceDefault).Delete(ctx, tcprouteSampleName, metav1.DeleteOptions{}))
+	require.Eventually(t, func() bool {
+		for _, conn := range conns {
+			_, err := conn.Write([]byte("blahhh\n"))
+			require.NoError(t, err)
+			err = conn.SetReadDeadline(time.Now().Add(time.Second * 3))
+			require.NoError(t, err)
+
+			reader := bufio.NewReader(conn)
+			_, err = reader.ReadBytes(byte('\n'))
+			if err != nil {
+				if strings.Contains(err.Error(), "i/o timeout") {
+					continue
+				}
+				t.Logf("received unexpected error waiting for TCPRoute to decomission: %s", err)
+			}
+			return false
+		}
+		return true
+	}, time.Minute, time.Second)
+}
+
+func removeName(names []string, name string) ([]string, bool) {
+	for i, v := range names {
+		if v == name {
+			names = append(names[:i], names[i+1:]...)
+			return names, true
+		}
+	}
+	return nil, false
+}
+
+func writeAndReadTCP(t *testing.T, conn net.Conn) string {
+	t.Helper()
+
+	t.Logf("writing data to TCP connection with backend %s", conn.RemoteAddr().String())
+	request := "wazzzaaaa"
+	_, err := conn.Write([]byte(request + "\n"))
+	require.NoError(t, err)
+
+	t.Logf("reading data from TCP connection with backend %s", conn.RemoteAddr().String())
+	reader := bufio.NewReader(conn)
+	response, err := reader.ReadBytes(byte('\n'))
+	require.NoError(t, err)
+	return string(response)
 }


### PR DESCRIPTION
Add support for round-robin load balancing for `TCPRoute`. This enables mutliple backend references in a UDPRoute object, with traffic being distributed to each backend in a round-robin fashion.

A new BPF map `TCP_CONNECTIONS` was introduced to help keep track of active TCP connections, with its key storing the clien <<ip:port>> identifier and the value storing the backend's <<ip:port>> along with the state of the connection.

Fixes #119 

Follow up items:
* modify `TCP_CONNECTIONS` to be more generic; get rid of `BLIXT_CONNTRACK` and refactor udp ingress and icmp egress to use the new generic map