### PR TITLE
Modify README/usage to address the current situation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,11 +331,13 @@ build.cluster: $(KTF) # builds a KIND cluster which can be used for testing and 
 .PHONY: load.image
 load.image: build.image
 	kind load docker-image $(BLIXT_CONTROLPLANE_IMAGE):$(TAG) --name $(KIND_CLUSTER) && \
-		kubectl -n blixt-system rollout restart deployment blixt-controlplane
+		kubectl -n blixt-system get deployment blixt-controlplane >/dev/null 2>&1 && \
+		kubectl -n blixt-system rollout restart deployment blixt-controlplane || true
 
 .PHONY: load.all.images
 load.all.images: build.all.images
 	kind load docker-image $(BLIXT_CONTROLPLANE_IMAGE):$(TAG) --name $(KIND_CLUSTER) && \
 	kind load docker-image $(BLIXT_DATAPLANE_IMAGE):$(TAG) --name $(KIND_CLUSTER) && \
 	kind load docker-image $(BLIXT_UDP_SERVER_IMAGE):$(TAG) --name $(KIND_CLUSTER) && \
-		kubectl -n blixt-system rollout restart deployment blixt-controlplane
+		kubectl -n blixt-system get deployment blixt-controlplane >/dev/null 2>&1 && \
+		kubectl -n blixt-system rollout restart deployment blixt-controlplane || true

--- a/README.md
+++ b/README.md
@@ -81,13 +81,30 @@ to have _you_ join us in iterating on it and helping us build it together!
 > (KIND)][kind] clusters. You can generate a new development cluster for
 > testing with `make build.cluster`.
 
-Deploy [Gateway API][gwapi] [CRDs][crds]:
+> **Note**: Currently our container images are under migration from a private repository.
+> At this moment, you should build and load images yourself.
+
+1. Deploy [Gateway API][gwapi] [CRDs][crds]:
 
 ```console
 kubectl apply -k https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.8.1
 ```
 
-Deploy:
+2. Build Blixt images:
+
+```console
+make build.all.images TAG=latest
+```
+
+3. Load images into your Kind cluster:
+
+```console
+make load.all.images TAG=latest
+```
+You may get an error like `Error from server (NotFound): namespaces "blixt-system" not found`, but please ignore it at this moment. The entire resources are created in the next step.
+
+
+4. Deploy Blixt:
 
 ```console
 kubectl apply -k config/default

--- a/README.md
+++ b/README.md
@@ -101,8 +101,6 @@ make build.all.images TAG=latest
 ```console
 make load.all.images TAG=latest
 ```
-You may get an error like `Error from server (NotFound): namespaces "blixt-system" not found`, but please ignore it at this moment. The entire resources are created in the next step.
-
 
 4. Deploy Blixt:
 


### PR DESCRIPTION
Currently, our image repository (ghcr.io) is private. So users should build and load images themselves.
This PR modifies The usage part in README to add that information.

Fixes: #175 