### PR TITLE
Dataplane: Add gRPC health check 

### DIFF
--- a/config/dataplane/dataplane.yaml
+++ b/config/dataplane/dataplane.yaml
@@ -28,3 +28,25 @@ spec:
         - name: RUST_LOG
           value: debug
         imagePullPolicy: IfNotPresent
+        # The gRPC API has a slow startup time, so this probe helps to provide some
+        # grace while starting up to avoid unnecessary kills.
+        #
+        # TODO: When we complete https://github.com/kubernetes-sigs/blixt/issues/173
+        # if we decide that we intend to keep the gRPC API around long term, we should
+        # take some time to see if we can clean up and improve the start time overall.
+        startupProbe:
+          grpc:
+            port: 9874
+          failureThreshold: 30
+          periodSeconds: 10
+        livenessProbe:
+          grpc:
+            port: 9874
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          grpc:
+            port: 9874
+          initialDelaySeconds: 5
+          periodSeconds: 5
+

--- a/dataplane/api-server/Cargo.toml
+++ b/dataplane/api-server/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 prost = "0.11.9"
 tonic = "0.9.2"
+tonic-health = "0.9.2"
 anyhow = "1"
 log = "0.4"
 aya = { version = ">=0.11", features=["async_tokio"] }

--- a/dataplane/api-server/src/lib.rs
+++ b/dataplane/api-server/src/lib.rs
@@ -24,9 +24,12 @@ pub async fn start(
     gateway_indexes_map: HashMap<MapData, BackendKey, u16>,
     tcp_conns_map: HashMap<MapData, ClientKey, LoadBalancerMapping>,
 ) -> Result<(), Error> {
+    let (_, health_service) = tonic_health::server::health_reporter();
+
     let server = server::BackendService::new(backends_map, gateway_indexes_map, tcp_conns_map);
     // TODO: mTLS https://github.com/Kong/blixt/issues/50
     Server::builder()
+        .add_service(health_service)
         .add_service(BackendsServer::new(server))
         .serve(SocketAddrV4::new(addr, port).into())
         .await?;


### PR DESCRIPTION
Currently our dataplane server doesn't have health check, so we can't confirm whether the dataplane daemonset runs properly or not.

This PR introduce health check for gRPC to the dataplane server, and add liveness, readiness, and startup probe for the daemonset.

Fixes: #51 