### PR TITLE
Add support for cross arch docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY pkg/ pkg/
 COPY internal/ internal/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ EXISTING_CLUSTER ?=
 
 # Image URL to use all building/pushing image targets
 TAG ?= integration-tests
+ifeq ($(shell uname -m),arm64)
+BUILD_PLATFORMS ?= linux/arm64
+else
+BUILD_PLATFORMS ?= linux/amd64
+endif
+BUILD_ARGS ?= --load
 
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
@@ -187,7 +193,7 @@ debug: manifests generate fmt vet ## Run a controller from your host via debugge
 
 .PHONY: build.image
 build.image:
-	DOCKER_BUILDKIT=1 docker build -t $(BLIXT_CONTROLPLANE_IMAGE):$(TAG) .
+	DOCKER_BUILDKIT=1 docker buildx build --platform=$(BUILD_PLATFORMS) $(BUILD_ARGS) -t $(BLIXT_CONTROLPLANE_IMAGE):$(TAG) .
 
 .PHONY: build.all.images
 build.all.images: build.image

--- a/dataplane/Dockerfile
+++ b/dataplane/Dockerfile
@@ -1,26 +1,40 @@
-FROM archlinux as builder
+FROM rust:1.75-slim-bookworm as builder
 
-RUN pacman -Syu --noconfirm
-RUN pacman -S base-devel protobuf rustup --noconfirm
+ARG TARGETARCH
+
+RUN apt-get update
+RUN apt-get install --yes build-essential protobuf-compiler pkg-config llvm-16
 
 RUN rustup default stable
 RUN rustup install nightly
 RUN rustup component add rust-src --toolchain nightly
-RUN rustup target add x86_64-unknown-linux-musl
 RUN --mount=type=cache,target=/root/.cargo/registry \
     cargo install bpf-linker
 
 WORKDIR /workspace
+# Docker uses the amd64/arm64 convention while Rust uses the x86_64/aarch64 convention.
+# Since Dockerfile doesn't support conditional variables (sigh), write the arch in Rust's
+# convention to a file for later usage.
+RUN if [ "$TARGETARCH" = "amd64" ]; \
+    then echo "x86_64" >> arch; \
+    else echo "aarch64" >> arch; \
+    fi
+RUN rustup target add $(eval cat arch)-unknown-linux-musl
 
 COPY . .
+
+# We need to tell bpf-linker where it can find LLVM's shared library file.
+# Ref: https://github.com/aya-rs/rustc-llvm-proxy/blob/cbcb3c6/src/lib.rs#L48
+ENV LD_LIBRARY_PATH="/usr/lib/llvm-16/lib"
+
 RUN --mount=type=cache,target=/workspace/target/ \
     --mount=type=cache,target=/root/.cargo/registry \
     cargo xtask build-ebpf --release
 RUN --mount=type=cache,target=/workspace/target/ \
     --mount=type=cache,target=/root/.cargo/registry \
-    RUSTFLAGS=-Ctarget-feature=+crt-static cargo build --release --target=x86_64-unknown-linux-musl
+    RUSTFLAGS=-Ctarget-feature=+crt-static cargo build --release --target=$(eval cat arch)-unknown-linux-musl
 RUN --mount=type=cache,target=/workspace/target/ \
-    cp /workspace/target/x86_64-unknown-linux-musl/release/loader /workspace/dataplane
+    cp /workspace/target/$(eval cat arch)-unknown-linux-musl/release/loader /workspace/dataplane
 
 FROM alpine
 

--- a/dataplane/Makefile
+++ b/dataplane/Makefile
@@ -2,6 +2,13 @@ IMAGE ?= ghcr.io/kubernetes-sigs/blixt-dataplane
 TAG ?= latest
 KIND_CLUSTER ?= blixt-dev
 
+ifeq ($(shell uname -m),arm64)
+BUILD_PLATFORMS ?= linux/arm64
+else
+BUILD_PLATFORMS ?= linux/amd64
+endif
+BUILD_ARGS ?= --load
+
 all: build
 
 .PHONY:
@@ -20,7 +27,7 @@ build.release:
 
 .PHONY: build.image
 build.image:
-	DOCKER_BUILDKIT=1 docker build -t $(IMAGE):$(TAG) ./
+	DOCKER_BUILDKIT=1 docker buildx build --platform $(BUILD_PLATFORMS) $(BUILD_ARGS) -t $(IMAGE):$(TAG) ./
 
 .PHONY: load.image
 load.image: build.image


### PR DESCRIPTION
Add support for cross architeture Docker builds. Since Arch linux doesn't have an official image for arm64, switch to Debian for building the dataplane.