### PR TITLE
Fix: detect when hardware platform is aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ EXISTING_CLUSTER ?=
 
 # Image URL to use all building/pushing image targets
 TAG ?= integration-tests
-ifeq ($(shell uname -m),arm64)
+ifeq ($(shell uname -m),$(filter $(shell uname -m),arm64 aarch64))
 BUILD_PLATFORMS ?= linux/arm64
 else
 BUILD_PLATFORMS ?= linux/amd64


### PR DESCRIPTION
Currently the makefile fails to select the correct build platform for arm devices that return `aarch64` as the result for `uname -m`.