### PR TITLE
fix warnings when build images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@
 # ------------------------------------------------------------------------------
 
 # IMAGES used when running tests.
-BLIXT_CONTROLPLANE_IMAGE ?= ghcr.io/kubernetes-sigs/blixt-controlplane
-BLIXT_DATAPLANE_IMAGE ?= ghcr.io/kubernetes-sigs/blixt-dataplane
-BLIXT_UDP_SERVER_IMAGE ?= ghcr.io/kubernetes-sigs/blixt-udp-test-server
+REGISTRY ?= ghcr.io/kubernetes-sigs
+BLIXT_CONTROLPLANE_IMAGE ?= $(REGISTRY)/blixt-controlplane
+BLIXT_DATAPLANE_IMAGE ?= $(REGISTRY)/blixt-dataplane
+BLIXT_UDP_SERVER_IMAGE ?= $(REGISTRY)/blixt-udp-test-server
 
 # Dockerfile paths for each service
 CONTROLPLANE_DOCKERFILE ?= build/Containerfile.controlplane

--- a/build/Containerfile.dataplane
+++ b/build/Containerfile.dataplane
@@ -1,4 +1,4 @@
-FROM rust:1.75-slim-bookworm as builder
+FROM rust:1.75-slim-bookworm AS builder
 
 ARG TARGETARCH
 

--- a/build/Containerfile.udp_server
+++ b/build/Containerfile.udp_server
@@ -1,4 +1,4 @@
-FROM rust as builder
+FROM rust AS builder
 
 RUN apt-get update && \
     apt-get install musl-tools -yq && \
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/workspace/target/ \
 
 FROM alpine
 
-LABEL org.opencontainers.image.source https://github.com/kubernetes-sigs/blixt
+LABEL org.opencontainers.image.source=https://github.com/kubernetes-sigs/blixt
 
 WORKDIR /
 

--- a/tools/performance/Dockerfile
+++ b/tools/performance/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-LABEL org.opencontainers.image.source https://github.com/kubernetes-sigs/blixt
+LABEL org.opencontainers.image.source=https://github.com/kubernetes-sigs/blixt
 
 RUN apk --no-cache add iperf3
 


### PR DESCRIPTION
fix warnings when build images
```
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
```
and
```
 => WARN: LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 5)                                                                           0.0s
 => WARN: LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 6)                                                                           0.0s
 => WARN: LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 8)  
```