### PR TITLE
fix: copy Cargo.lock when building dataplane

### DIFF
--- a/build/Containerfile.dataplane
+++ b/build/Containerfile.dataplane
@@ -30,6 +30,7 @@ COPY dataplane dataplane
 COPY tools/udp-test-server tools/udp-test-server
 COPY xtask xtask
 COPY Cargo.toml Cargo.toml
+COPY Cargo.lock Cargo.lock
 COPY .cargo .cargo
 
 # We need to tell bpf-linker where it can find LLVM's shared library file.


### PR DESCRIPTION
Fixes #291 

An even better solution is to update Aya and fix the references used. But I think we should copy `Cargo.lock` nonetheless during build time