### PR TITLE
fix: controlplane Dockerfile

### DIFF
--- a/build/Containerfile.controlplane
+++ b/build/Containerfile.controlplane
@@ -1,15 +1,16 @@
-FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx-tools
 
 FROM --platform=$BUILDPLATFORM rust:alpine
 ARG TARGETPLATFORM
+ARG PROJECT_DIR=/workspace
+ARG BUILD_DIR=$PROJECT_DIR/build
 
-RUN apk add clang lld
-COPY --from=xx / /
+RUN apk add --no-cache clang lld
+COPY --from=xx-tools / /
 
 WORKDIR /workspace
-
-RUN --mount=type=bind,source=src,target=src \
-    --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
-    --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
-    xx-cargo build --release --target-dir ./build && \
+RUN --mount=type=bind,source=../controlplane/src/,target=src \
+    --mount=type=bind,source=../controlplane/Cargo.toml,target=Cargo.toml \
+    --mount=type=bind,source=../controlplane/Cargo.lock,target=Cargo.lock \
+    xx-cargo build --release --target-dir $BUILD_DIR && \
     xx-verify ./build/$(xx-cargo --print-target-triple)/release/controller


### PR DESCRIPTION
## Description

The `make build.image.controlplane` command was failing due to incorrect file paths for `src`, `Cargo.toml`, and `Cargo.lock`. This PR updates the Dockerfile to reference the correct paths within the `controlplane` directory

## Testing

To test this change:
1. Clone the repository.
2. Run `make build.image.controlplane`.  
   The build should complete successfully without any errors.
