### PR TITLE
fix dataplane loader 

### DIFF
--- a/dataplane/loader/src/main.rs
+++ b/dataplane/loader/src/main.rs
@@ -32,15 +32,14 @@ async fn main() -> Result<(), anyhow::Error> {
 
     info!("loading ebpf programs");
 
-    let mut bpf_program = if cfg!(debug_assertions) {
-        let path = "../../target/bpfel-unknown-none/debug/loader";
-        let bytes = fs::read(Path::new(path)).expect("Failed to read debug loader");
-        Ebpf::load(&bytes).expect("Failed to load eBPF program")
+    let path = if cfg!(debug_assertions) {
+        "../../target/bpfel-unknown-none/debug/loader"
     } else {
-        let path = "../../target/bpfel-unknown-none/release/loader";
-        let bytes = fs::read(Path::new(path)).expect("Failed to read release loader");
-        Ebpf::load(&bytes).expect("Failed to load eBPF program")
+        "../../target/bpfel-unknown-none/release/loader"
     };
+
+    let bytes = fs::read(Path::new(path))?;
+    let mut bpf_program = Ebpf::load(&bytes)?;
     
     if let Err(e) = EbpfLogger::init(&mut bpf_program) {
         warn!("failed to initialize eBPF logger: {}", e);

--- a/dataplane/loader/src/main.rs
+++ b/dataplane/loader/src/main.rs
@@ -4,6 +4,7 @@ Copyright 2023 The Kubernetes Authors.
 SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 */
 
+use std::fs;
 use std::net::Ipv4Addr;
 
 use anyhow::Context;
@@ -30,14 +31,14 @@ async fn main() -> Result<(), anyhow::Error> {
 
     info!("loading ebpf programs");
 
+    let path = "../../target/bpfel-unknown-none/debug/loader";
+    let bytes = fs::read(path);
+
     #[cfg(debug_assertions)]
-    let mut bpf_program = Ebpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/debug/loader"
-    ))?;
+    let mut bpf_program = Ebpf::load(&bytes)?;
+    
     #[cfg(not(debug_assertions))]
-    let mut bpf = Ebpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/release/loader"
-    ))?;
+    let mut bpf = Ebpf::load(&bytes)?;
     if let Err(e) = EbpfLogger::init(&mut bpf_program) {
         warn!("failed to initialize eBPF logger: {}", e);
     }

--- a/dataplane/loader/src/main.rs
+++ b/dataplane/loader/src/main.rs
@@ -12,7 +12,7 @@ use anyhow::Context;
 use api_server::start as start_api_server;
 use aya::maps::HashMap;
 use aya::programs::{tc, SchedClassifier, TcAttachType};
-use aya::{include_bytes_aligned, Ebpf};
+use aya::Ebpf;
 use aya_log::EbpfLogger;
 use clap::Parser;
 use common::{BackendKey, BackendList, ClientKey, LoadBalancerMapping};


### PR DESCRIPTION
## Description

The error was `error cannot find value 'bpf-program' in this scope`,because the variable `bpf_program` is only available when `debug_assertions` is enabled, so fixed it by using correct variable whether pogram is in release build or debug and also the `include_bytes_aligned!` macro was unable to load the file at runtime. Replaced with `fs::read()` to load the file 

## Testing

To test this change:

1. Clone the repository.
2. Run `make build.image.dataplane`.
3. Ensure the build completes successfully without any errors.
