### PR TITLE
shrink controlplane image size

### DIFF
--- a/build/Containerfile.controlplane
+++ b/build/Containerfile.controlplane
@@ -1,6 +1,6 @@
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx-tools
 
-FROM --platform=$BUILDPLATFORM rust:alpine
+FROM --platform=$BUILDPLATFORM rust:alpine AS builder
 ARG TARGETPLATFORM
 ARG PROJECT_DIR=/workspace
 ARG BUILD_DIR=$PROJECT_DIR/build
@@ -13,4 +13,8 @@ RUN --mount=type=bind,source=../controlplane/src/,target=src \
     --mount=type=bind,source=../controlplane/Cargo.toml,target=Cargo.toml \
     --mount=type=bind,source=../controlplane/Cargo.lock,target=Cargo.lock \
     xx-cargo build --release --target-dir $BUILD_DIR && \
-    xx-verify ./build/$(xx-cargo --print-target-triple)/release/controller
+    xx-verify ./build/$(xx-cargo --print-target-triple)/release/manager && \
+    cp ./build/$(xx-cargo --print-target-triple)/release/manager /manager
+
+FROM alpine
+COPY --from=builder /manager /manager

--- a/controlplane/Cargo.toml
+++ b/controlplane/Cargo.toml
@@ -7,13 +7,18 @@ edition = "2021"
 
 [[bin]]
 doc = false
-name = "controller"
+name = "manager"
 path = "src/main.rs"
 
 [dependencies]
 futures = "0.3.28"
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread"] }
-kube = { version = "^0.88.0", default-features = false, features = ["runtime", "client", "derive", "rustls-tls"] }
+kube = { version = "^0.88.0", default-features = false, features = [
+    "runtime",
+    "client",
+    "derive",
+    "rustls-tls",
+] }
 k8s-openapi = { version = "0.21.1", features = ["latest"] }
 serde = { version = "1.0.185", features = ["derive"] }
 chrono = { version = "0.4.33", features = ["serde"] }
@@ -24,4 +29,3 @@ tracing-subscriber = "0.3"
 thiserror = "1.0.47"
 anyhow = "1.0.75"
 gateway-api = "0.9.0"
-


### PR DESCRIPTION
Before
```
➜ /workspaces/blixt (main) $ docker images                                                                                       
REPOSITORY                                   TAG                 IMAGE ID       CREATED          SIZE                                    
ghcr.io/kubernetes-sigs/blixt-controlplane   integration-tests   8973d0b96975   12 seconds ago   1.73GB
```

After
```
➜ /workspaces/blixt (shrink_image) $ docker images
REPOSITORY                                   TAG                 IMAGE ID       CREATED          SIZE
ghcr.io/kubernetes-sigs/blixt-controlplane   integration-tests   e7042923b93c   2 minutes ago    18.8MB
```