### PR TITLE
(fix): incorrect logs in controlplane

### DIFF
--- a/controlplane/src/gateway_controller.rs
+++ b/controlplane/src/gateway_controller.rs
@@ -142,7 +142,7 @@ pub async fn reconcile(gateway: Arc<Gateway>, ctx: Arc<Context>) -> Result<Actio
         service = create_svc_for_gateway(ctx.clone(), gateway.as_ref()).await?;
     }
 
-    // invalid_lb_condition is a Condition that signfies that the Loadbalancer service is invalid.
+    // invalid_lb_condition is a Condition that signifies that the Loadbalancer service is invalid.
     let mut invalid_lb_condition = metav1::Condition {
         last_transition_time: metav1::Time(Utc::now()),
         observed_generation: gateway.meta().generation,

--- a/controlplane/src/main.rs
+++ b/controlplane/src/main.rs
@@ -36,7 +36,7 @@ pub async fn run() {
     };
 
     if let Err(error) = gateway_controller::controller(ctx).await {
-        error!("failed to start Gateway contoller: {error:?}");
+        error!("failed to start Gateway controller: {error:?}");
         std::process::exit(1);
     }
 }

--- a/dataplane/api-server/src/netutils.rs
+++ b/dataplane/api-server/src/netutils.rs
@@ -16,7 +16,7 @@ use std::net::Ipv4Addr;
 const ERR_NO_IFINDEX: &str = "no ifindex found to route";
 const ERR_PACKET_CONSTRUCTION: &str = "construct packet failed";
 
-/// Returns an network interface index for a Ipv4 address (like the command `ip route get to $IP`)
+/// Returns a network interface index for an IPv4 address (like the command `ip route get to $IP`)
 pub fn if_index_for_routing_ip(ip_addr: Ipv4Addr) -> Result<u32, Error> {
     let socket = Socket::new(NETLINK_ROUTE)?;
     socket.connect(&SocketAddr::new(0, 0))?;


### PR DESCRIPTION
This PR fixes minor typos in controlplane logs and comment docs of dp components. 