### PR TITLE
(feat): debug logs on data plane for health service addresses

### DIFF
--- a/dataplane/api-server/src/lib.rs
+++ b/dataplane/api-server/src/lib.rs
@@ -45,6 +45,8 @@ pub async fn start(
         let (_, health_service) = tonic_health::server::health_reporter();
         let mut server_builder = Server::builder();
 
+        // by convention we add 1 to the API listen port and use that
+        // for the health check port.
         let port = port + 1;
         let addr = SocketAddrV4::new(addr, port);
         let server = server_builder

--- a/dataplane/api-server/src/lib.rs
+++ b/dataplane/api-server/src/lib.rs
@@ -16,7 +16,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use aya::maps::{HashMap, MapData};
-use log::{debug, info, error};
+use log::{debug, info};
 use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
 
 use backends::backends_server::BackendsServer;
@@ -52,7 +52,9 @@ pub async fn start(
             .serve(addr.into());
 
         debug!("gRPC Health Checking service listens on {}", addr);
-        server.await.expect("Failed to serve gRPC Health Checking service");
+        server
+            .await
+            .expect("Failed to serve gRPC Health Checking service");
     });
 
     // Secure server with (optional) mTLS
@@ -140,6 +142,6 @@ pub fn setup_tls(mut builder: Server, tls_config: &Option<TLSConfig>) -> Result<
         None => {
             info!("gRPC TLS is not enabled");
             Ok(builder)
-        },
+        }
     }
 }

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -45,7 +45,7 @@ fn build_dataplane(opts: &Options) -> Result<(), anyhow::Error> {
 }
 
 /// Build the controlplane
-fn build_contrlplane(opts: &Options) -> Result<(), anyhow::Error> {
+fn build_controlplane(opts: &Options) -> Result<(), anyhow::Error> {
     let mut args = vec!["build", "--package", "controlplane"];
     if opts.release {
         args.push("--release")
@@ -92,7 +92,7 @@ pub fn run_dataplane(opts: Options) -> Result<(), anyhow::Error> {
 }
 
 pub fn run_controlplane(opts: Options) -> Result<(), anyhow::Error> {
-    build_contrlplane(&opts).context("Error while building controlplane")?;
+    build_controlplane(&opts).context("Error while building controlplane")?;
 
     // profile we are building (release or debug)
     let profile = if opts.release { "release" } else { "debug" };

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -84,7 +84,7 @@ pub fn run_dataplane(opts: Options) -> Result<(), anyhow::Error> {
     // spawn the command
     let err = Command::new(args.first().expect("No first argument"))
         .args(args.iter().skip(1))
-        .env("RUST_LOG", "info")
+        .env("RUST_LOG", "info,api_server=debug")
         .exec();
 
     // we shouldn't get here unless the command failed to spawn


### PR DESCRIPTION
This PR
- adds debug and info logs to print out addresses & ports being used by data plane for gRPC health service.
- updates xtask command to run data plane with debug log level for `api_server`
- fixes incorrect xtask command name for controlplane (typo).