### PR TITLE
Add integration test infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,6 +1345,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,8 +1774,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1777,7 +1795,7 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1785,6 +1803,12 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2167,6 +2191,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tests-integration"
+version = "0.3.0"
+dependencies = [
+ "k8s-openapi",
+ "kube",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2443,8 +2479,12 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "thread_local",
+ "tracing",
  "tracing-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
 	"dataplane/api-server",
 	"dataplane/common",
 	"dataplane/loader",
+	"tests-integration",
 	"tools/udp-test-server",
 	"xtask",
 ]

--- a/build/Containerfile.controlplane
+++ b/build/Containerfile.controlplane
@@ -18,6 +18,8 @@ COPY controlplane/ controlplane/
 
 COPY dataplane/ dataplane/
 
+COPY tests-integration/ tests-integration/
+
 COPY tools/ tools/
 
 COPY xtask/ xtask/

--- a/build/Containerfile.dataplane
+++ b/build/Containerfile.dataplane
@@ -40,6 +40,8 @@ COPY controlplane/ controlplane/
 
 COPY dataplane/ dataplane/
 
+COPY tests-integration/ tests-integration/
+
 COPY tools/ tools/
 
 COPY xtask/ xtask/

--- a/build/Containerfile.udp_test_server
+++ b/build/Containerfile.udp_test_server
@@ -8,8 +8,6 @@ RUN apk add --no-cache musl-dev clang lld
 
 WORKDIR /workspace
 
-WORKDIR /workspace
-
 ARG PROJECT_DIR=/workspace
 
 ARG BUILD_DIR=$PROJECT_DIR/build
@@ -19,6 +17,8 @@ COPY Cargo.toml Cargo.lock ./
 COPY controlplane/ controlplane/
 
 COPY dataplane/ dataplane/
+
+COPY tests-integration/ tests-integration/
 
 COPY tools/ tools/
 

--- a/config/dataplane/dataplane.yaml
+++ b/config/dataplane/dataplane.yaml
@@ -24,6 +24,8 @@ spec:
         securityContext:
           privileged: true
         args: ["-i", "eth0"]
+        ports:
+          - containerPort: 9874
         env:
         - name: RUST_LOG
           value: debug

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -45,5 +45,3 @@ resources:
 - ../rbac
 - ../manager
 - ../dataplane
-patches:
-- path: manager_auth_proxy_patch.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,7 +35,7 @@ spec:
         #   type: RuntimeDefault
       containers:
       - command:
-        - /workspace/manager
+        - /controller
         args:
         - --leader-elect
         image: ghcr.io/kubernetes-sigs/blixt-controlplane:latest
@@ -47,14 +47,12 @@ spec:
             drop:
               - "ALL"
         livenessProbe:
-          httpGet:
-            path: /healthz
+          grpc:
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
-          httpGet:
-            path: /readyz
+          grpc:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/config/tests/metallb/ipaddresspool.yaml
+++ b/config/tests/metallb/ipaddresspool.yaml
@@ -1,0 +1,9 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: blixt-system-pool
+spec:
+  addresses:
+    - 10.89.0.100-10.89.0.250
+  autoAssign: true
+  avoidBuggyIPs: false

--- a/config/tests/metallb/kustomization.yaml
+++ b/config/tests/metallb/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metallb-system
+resources:
+  - ipaddresspool.yaml
+  - l2advertisement.yaml

--- a/config/tests/metallb/l2advertisement.yaml
+++ b/config/tests/metallb/l2advertisement.yaml
@@ -1,0 +1,4 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: blixt-system-pool

--- a/controlplane/src/main.rs
+++ b/controlplane/src/main.rs
@@ -13,11 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 use controlplane::*;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 use kube::Client;
+use tokio::task::JoinHandle;
 use tokio::try_join;
+use tonic::transport::Server;
 use tracing::*;
 
 #[tokio::main]
@@ -46,8 +48,35 @@ pub async fn run() {
     if let Err(error) = try_join!(
         gateway_controller(ctx.clone()),
         gatewayclass_controller(ctx),
+        setup_health_checks(IpAddr::from(Ipv4Addr::new(0, 0, 0, 0)), 8080)
     ) {
         error!("failed to start controllers: {error:?}");
         std::process::exit(1);
     }
+}
+
+// TODO: integrate with DataplaneClientManager connection status
+// only get healthy once the dataplane pod connections are established
+async fn setup_health_checks(addr: IpAddr, port: u16) -> Result<JoinHandle<()>> {
+    let healthchecks = tokio::spawn(async move {
+        let (_, health_service) = tonic_health::server::health_reporter();
+        let server_builder = Server::builder();
+
+        // by convention we add 1 to the API listen port and use that
+        // for the health check port.
+        let port = port + 1;
+
+        let addr = match addr {
+            IpAddr::V4(v4) => SocketAddr::V4(SocketAddrV4::new(v4, port)),
+            IpAddr::V6(v6) => SocketAddr::V6(SocketAddrV6::new(v6, port, 0, 0)),
+        };
+
+        let server = server_builder.serve(addr, health_service);
+
+        debug!("gRPC Health Checking service listens on {addr}");
+        server
+            .await
+            .expect("Failed to serve gRPC Health Checking service");
+    });
+    Ok(healthchecks)
 }

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tests-integration"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+k8s-openapi= { workspace = true, features = ["v1_32"] }
+kube = { workspace = true, features = ["client", "rustls-tls", "ring"] }
+thiserror.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "process"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+tracing.workspace = true

--- a/tests-integration/src/infrastructure/kind_cluster.rs
+++ b/tests-integration/src/infrastructure/kind_cluster.rs
@@ -1,0 +1,263 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::time::Duration;
+
+use kube::config::KubeConfigOptions;
+use kube::{Client, Config};
+use thiserror::Error as ThisError;
+use tracing::{error, info};
+
+use crate::Result;
+use crate::infrastructure::{
+    AsyncCommand, AsyncCommandError, ContainerState, Workload, WorkloadImageTag,
+};
+
+/// Single-node kind cluster.
+#[derive(Clone, Debug)]
+pub struct KindCluster {
+    name: String,
+}
+
+/// Errors originating from [`KindCluster`].
+#[allow(missing_docs)]
+#[derive(ThisError, Debug)]
+pub enum KindClusterError {
+    #[error("{0}: {1}")]
+    Execution(String, AsyncCommandError),
+    #[error("{0} container state {1:?}")]
+    ContainerState(String, ContainerState),
+    #[error("Failed to create client {1} for k8s context {0:?}")]
+    Client(String, String),
+    #[error("Could not determine container id for ter  {0}")]
+    NotFound(String),
+    #[error("loading image: {1}:{2} to cluster {0} failed: {3}")]
+    LoadImage(String, String, String, String),
+}
+
+impl KindCluster {
+    /// create a new cluster
+    pub fn new<T: AsRef<str>>(name: T) -> Result<Self> {
+        Ok(KindCluster {
+            name: name.as_ref().to_string(),
+        })
+    }
+
+    /// get the clusters name
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    /// get the k8s context name
+    pub fn k8s_context(&self) -> String {
+        format!("kind-{}", self.name)
+    }
+
+    /// get a `kube::Client` for the cluster
+    pub async fn k8s_client(&self) -> Result<Client> {
+        let kube_config = KubeConfigOptions {
+            context: Some(self.k8s_context()),
+            cluster: None,
+            user: None,
+        };
+        let cfg = Config::from_kubeconfig(&kube_config)
+            .await
+            .map_err(|e| KindClusterError::Client(self.k8s_context(), e.to_string()))?;
+
+        let client = Client::try_from(cfg)
+            .map_err(|e| KindClusterError::Client(self.k8s_context(), e.to_string()))?;
+
+        Ok(client)
+    }
+
+    /// create the cluster
+    pub async fn create(&self) -> Result<()> {
+        AsyncCommand::new("kind", &["create", "cluster", "--name", self.name.as_str()])
+            .run()
+            .await
+            .map_err(|e| {
+                KindClusterError::Execution(
+                    format!("Failed to create kind cluster {}", self.name),
+                    e,
+                )
+                .into()
+            })
+    }
+
+    /// delete the cluster
+    pub async fn delete(&self) -> Result<()> {
+        AsyncCommand::new("kind", &["delete", "cluster", "--name", self.name.as_str()])
+            .run()
+            .await
+            .map_err(|e| {
+                KindClusterError::Execution(
+                    format!("Failed to create kind cluster {}", self.name),
+                    e,
+                )
+                .into()
+            })
+    }
+
+    /// load a container image into the cluster
+    pub async fn load_image(&self, image: &str, tag: &str) -> Result<()> {
+        let kind_cluster = &self.name;
+        info!("Loading image {image} with {tag} to kind cluster {kind_cluster:?}.");
+        AsyncCommand::new(
+            "kind",
+            &[
+                "load",
+                "docker-image",
+                format!("{image}:{tag}").as_str(),
+                "--name",
+                kind_cluster,
+            ],
+        )
+        .run()
+        .await
+        .map_err(|e| {
+            KindClusterError::LoadImage(
+                kind_cluster.to_string(),
+                image.to_string(),
+                tag.to_string(),
+                e.to_string(),
+            )
+            .into()
+        })
+    }
+
+    /// In case wait_status is `None` the rollout will not wait for success
+    /// In case wait_status is `Some(Duration)` the rollout waits for success with
+    /// the duration as timeout in seconds
+    pub async fn rollout<T: AsRef<WorkloadImageTag>>(
+        &self,
+        workload: T,
+        wait_status: Option<Duration>,
+    ) -> Result<()> {
+        let workload = workload.as_ref();
+        let k8s_ctx = self.k8s_context();
+
+        let (workload_type, namespace, name) = workload.workload_namespace_name();
+
+        // update deployment image references in case specified
+        if let Some((image, tag)) = workload.image_tag() {
+            info!(
+                "Updating image {image} with tag {tag} for rollout {}.",
+                workload.id
+            );
+            AsyncCommand::new(
+                "kubectl",
+                &[
+                    format!("--context={k8s_ctx}").as_str(),
+                    "set",
+                    "image",
+                    "-n",
+                    namespace,
+                    format!("{workload_type}/{name}").as_str(),
+                    format!("*={image}:{tag}").as_str(),
+                ],
+            )
+            .run()
+            .await
+            .map_err(|e| {
+                KindClusterError::Execution(
+                    format!("Failed to set image for {namespace} {workload_type}/{name} failed"),
+                    e,
+                )
+            })?;
+        }
+
+        info!("Restarting rollout {}.", workload.id);
+        AsyncCommand::new(
+            "kubectl",
+            &[
+                format!("--context={k8s_ctx}").as_str(),
+                "rollout",
+                "restart",
+                "-n",
+                namespace,
+                format!("{workload_type}/{name}").as_str(),
+            ],
+        )
+        .run()
+        .await
+        .map_err(|e| {
+            KindClusterError::Execution(
+                format!("Rollout restart for {namespace} {workload_type}/{name} failed"),
+                e,
+            )
+        })?;
+
+        if let Some(wait_status) = wait_status {
+            self.rollout_status(&workload.id, wait_status).await?;
+        };
+
+        Ok(())
+    }
+
+    /// In case wait_status is `None` the rollouts will not wait for success
+    /// In case wait_status is `Some(Duration)` the rollouts are waiting for success with
+    /// the duration as timeout in seconds per rollout
+    /// the total timeout can reach up to the number of rollouts * wait_status `Duration`
+    pub async fn rollouts<T: AsRef<WorkloadImageTag>>(
+        &self,
+        workloads: &[T],
+        wait_status: Option<Duration>,
+    ) -> Result<()> {
+        for workload in workloads {
+            self.rollout(workload, wait_status).await?;
+        }
+        Ok(())
+    }
+
+    /// wait for a rollout status to be successful
+    pub async fn rollout_status<T: AsRef<Workload>>(
+        &self,
+        workload: T,
+        timeout_secs: Duration,
+    ) -> Result<()> {
+        let k8s_ctx = self.k8s_context();
+        let timeout = timeout_secs.as_secs().to_string();
+        let workload = workload.as_ref();
+
+        info!(
+            "Waiting for rollout {} to complete. Timeout: {}s",
+            workload, timeout
+        );
+        let (workload_type, namespace, name) = workload.workload_namespace_name();
+        AsyncCommand::new(
+            "kubectl",
+            &[
+                format!("--context={k8s_ctx}").as_str(),
+                "rollout",
+                "status",
+                "-n",
+                namespace,
+                format!("{workload_type}/{name}").as_str(),
+                "--timeout",
+                format!("{timeout}s").as_str(),
+            ],
+        )
+        .run()
+        .await
+        .map_err(|e| {
+            KindClusterError::Execution(
+                format!("Rollout status for {namespace} {workload_type}/{name} failed"),
+                e,
+            )
+            .into()
+        })
+    }
+}

--- a/tests-integration/src/infrastructure/kustomize.rs
+++ b/tests-integration/src/infrastructure/kustomize.rs
@@ -1,0 +1,165 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error as ThisError;
+use tracing::error;
+
+use crate::Result;
+use crate::infrastructure::{AsyncCommand, AsyncCommandError, KindCluster, KindClusterError};
+
+/// Errors originating from [`KustomizeDeployments`].
+#[allow(missing_docs)]
+#[derive(ThisError, Debug)]
+pub enum KustomizeError {
+    #[error("path {0} is invalid {1:?}")]
+    InvalidPath(String, String),
+    #[error("failed to render kustomize input {0:?}")]
+    Render(AsyncCommandError),
+    #[error("apply error: {0}")]
+    Apply(AsyncCommandError),
+    #[error(transparent)]
+    Kind(#[from] KindClusterError),
+}
+
+/// Set of kustomize deployments linked to a cluster.
+pub struct KustomizeDeployments {
+    cluster: KindCluster,
+    kustomizations: Vec<KustomizeKind>,
+}
+
+enum KustomizeKind {
+    Directory(PathBuf),
+    File(PathBuf),
+    Https(String),
+}
+
+impl KustomizeDeployments {
+    /// create a set of kustomize deployments
+    pub async fn new<D: IntoIterator<Item = impl AsRef<str>>>(
+        cluster: KindCluster,
+        kustomizations: D,
+    ) -> Result<Self> {
+        let mut validated_kustomizations = vec![];
+        for k in kustomizations.into_iter() {
+            validated_kustomizations.push(KustomizeKind::try_from(k.as_ref()).await?);
+        }
+
+        Ok(Self {
+            cluster,
+            kustomizations: validated_kustomizations,
+        })
+    }
+
+    /// apply the kustomize deployments on the provided cluster
+    pub async fn apply(&self) -> Result<()> {
+        let k8s_ctx = self.cluster.k8s_context();
+        for deployment in &self.kustomizations {
+            let inner = deployment.inner();
+            match deployment.needs_k() {
+                true => AsyncCommand::new(
+                    "kubectl",
+                    &[
+                        format!("--context={k8s_ctx}").as_str(),
+                        "apply",
+                        "-k",
+                        inner.as_str(),
+                    ],
+                ),
+                false => AsyncCommand::new(
+                    "kubectl",
+                    &[
+                        format!("--context={k8s_ctx}").as_str(),
+                        "apply",
+                        inner.as_str(),
+                    ],
+                ),
+            }
+            .run()
+            .await
+            .map_err(KustomizeError::Apply)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl KustomizeKind {
+    async fn try_from<D: AsRef<str>>(kustomization: D) -> Result<KustomizeKind> {
+        let kustomization = kustomization.as_ref();
+
+        let kind = match kustomization {
+            _ if kustomization.starts_with("https://") => {
+                KustomizeKind::Https(kustomization.to_string())
+            }
+            _ => {
+                let path = kustomization.to_string();
+                let fs_path = Path::new(&path);
+
+                let exists = fs_path
+                    .try_exists()
+                    .map_err(|e| KustomizeError::InvalidPath(path.to_string(), e.to_string()))?;
+                if !exists {
+                    return Err(KustomizeError::InvalidPath(
+                        path.to_string(),
+                        "does not exist".to_string(),
+                    )
+                    .into());
+                }
+
+                match fs_path.is_dir() {
+                    true => KustomizeKind::Directory(fs_path.to_path_buf()),
+                    false => KustomizeKind::File(fs_path.to_path_buf()),
+                }
+            }
+        };
+
+        kind.validate().await
+    }
+
+    async fn validate(self) -> Result<Self> {
+        match &self {
+            KustomizeKind::Directory(_) | KustomizeKind::File(_) => {
+                let inner = self.inner();
+                AsyncCommand::new("kubectl", &["kustomize", inner.as_str()])
+                    .run()
+                    .await
+                    .map_err(KustomizeError::Render)?;
+            }
+            KustomizeKind::Https(_) => { /* skipping, typically valid, and validation is relatively slow */
+            }
+        }
+
+        Ok(self)
+    }
+
+    fn needs_k(&self) -> bool {
+        match self {
+            KustomizeKind::Directory(_) => true,
+            KustomizeKind::File(_) => false,
+            KustomizeKind::Https(_) => true,
+        }
+    }
+
+    fn inner(&self) -> String {
+        match self {
+            KustomizeKind::Directory(d) => d.as_os_str().to_string_lossy().to_string(),
+            KustomizeKind::File(d) => d.as_os_str().to_string_lossy().to_string(),
+            KustomizeKind::Https(d) => d.clone(),
+        }
+    }
+}

--- a/tests-integration/src/infrastructure/mod.rs
+++ b/tests-integration/src/infrastructure/mod.rs
@@ -1,0 +1,207 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Contains structs to create clusters and k8s resources.
+//! The resources can be connected and allow for integration.
+//!
+//! For example to create a [`KindCluster`], load container images into
+//! the [`KindCluster`] and deploy a set of k8s resources through a [`KustomizeDeployments`].
+
+mod kind_cluster;
+mod kustomize;
+
+pub use kind_cluster::KindCluster;
+pub use kind_cluster::KindClusterError;
+pub use kustomize::KustomizeDeployments;
+pub use kustomize::KustomizeError;
+
+use std::ffi::OsStr;
+use std::fmt::{Debug, Display, Formatter};
+use std::io;
+
+use thiserror::Error;
+use tokio::process::Command;
+use tracing::{error, info};
+
+/// Represents a Container state.
+///
+/// Refers to the containers `.State` property (in case a container was found).
+#[allow(missing_docs)]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ContainerState {
+    Running,
+    Exited,
+    NotFound,
+}
+
+/// K8s workload type with a corresponding identifier.
+#[allow(missing_docs)]
+#[derive(Clone)]
+pub enum Workload {
+    DaemonSet(NamespacedName),
+    Deployment(NamespacedName),
+}
+
+/// Fully qualified image name including tag.
+#[allow(missing_docs)]
+#[derive(Debug)]
+pub struct ImageTag {
+    /// image fully qualified name
+    pub image: String,
+    pub tag: String,
+}
+
+/// A [`Workload`] with an optional image tag.
+///
+/// In case an image tag is available the workload image references
+/// will be updated to the according `image:tag` before an action is executed
+/// e.g. the Deployments image field is updated, and then a rollout restart is carried out
+#[derive(Debug)]
+pub struct WorkloadImageTag {
+    /// workload identifier
+    pub id: Workload,
+    /// optional image tag
+    pub image_tag: Option<ImageTag>,
+}
+
+impl WorkloadImageTag {
+    fn image_tag(&self) -> Option<(&str, &str)> {
+        self.image_tag
+            .as_ref()
+            .map(|it| (it.image.as_str(), it.tag.as_str()))
+    }
+    fn workload_namespace_name(&self) -> (&str, &str, &str) {
+        self.id.workload_namespace_name()
+    }
+}
+
+impl Workload {
+    fn workload_namespace_name(&self) -> (&str, &str, &str) {
+        match &self {
+            Workload::DaemonSet(id) => ("daemonset", id.namespace.as_str(), id.name.as_str()),
+            Workload::Deployment(id) => ("deployment", id.namespace.as_str(), id.name.as_str()),
+        }
+    }
+}
+
+/// Wraps a `tokio::process::Command` for easier handling.
+///
+/// The crate uses this struct for all executions, which allows to use helpers
+/// like `tokio::try_join` to e.g. parallelize image build and cluster creation.
+struct AsyncCommand {
+    cmd: Command,
+}
+
+/// Errors originating from [`AsyncCommand`].
+#[allow(missing_docs)]
+#[derive(Error, Debug)]
+pub enum AsyncCommandError {
+    #[error("Failed spawning the command: {0:?}")]
+    Spawn(io::Error),
+    #[error("Failed to wait for the command: {0:?}")]
+    Wait(io::Error),
+    #[error("Failed getting output for the command: {0:?}")]
+    Output(io::Error),
+    #[error("Command exited with {0:?}")]
+    ExitStatus(Option<i32>),
+}
+
+impl AsyncCommand {
+    /// create a new AsyncCommand by providing the command binary and the arguments
+    pub fn new<C: AsRef<OsStr>, A: AsRef<OsStr>>(cmd: C, args: &[A]) -> Self {
+        let mut cmd = Command::new(cmd);
+        {
+            args.iter().for_each(|a| {
+                let _ = &mut cmd.arg(a);
+            });
+        }
+        Self { cmd }
+    }
+
+    async fn run(&mut self) -> Result<(), AsyncCommandError> {
+        info!("run: {:?}", self.cmd);
+        let exit_status = self
+            .cmd
+            .spawn()
+            .map_err(AsyncCommandError::Spawn)?
+            .wait()
+            .await
+            .map_err(AsyncCommandError::Wait)?;
+
+        if !exit_status.success() {
+            return Err(AsyncCommandError::ExitStatus(exit_status.code()));
+        }
+
+        Ok(())
+    }
+}
+
+impl Display for Workload {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let id = match self {
+            Workload::DaemonSet(id) => {
+                f.write_str("daemonset")?;
+                id
+            }
+            Workload::Deployment(id) => {
+                f.write_str("deployment")?;
+                id
+            }
+        };
+        f.write_str(" ")?;
+        Display::fmt(id, f)
+    }
+}
+
+impl Debug for Workload {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl AsRef<WorkloadImageTag> for WorkloadImageTag {
+    fn as_ref(&self) -> &WorkloadImageTag {
+        self
+    }
+}
+
+impl AsRef<Workload> for Workload {
+    fn as_ref(&self) -> &Workload {
+        self
+    }
+}
+
+/// K8s identifier consisting of a namespace and a name.
+#[allow(missing_docs)]
+#[derive(Clone)]
+pub struct NamespacedName {
+    pub namespace: String,
+    pub name: String,
+}
+
+impl Display for NamespacedName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.namespace.as_str())?;
+        f.write_str("/")?;
+        f.write_str(self.name.as_str())
+    }
+}
+
+impl Debug for NamespacedName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}

--- a/tests-integration/src/lib.rs
+++ b/tests-integration/src/lib.rs
@@ -1,0 +1,91 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! [`kind_k8s`](`crate`) provides elements that allow to build container images,
+//! to create [kind](https://kind.sigs.k8s.io/) (k8s in docker) clusters and to deploy k8s resources using
+//! [kustomize](https://kustomize.io/) through [kubectl](https://kubernetes.io/docs/reference/kubectl/).
+//!
+//! This [`crate`] depends on the host to have the following tools installed and correctly configured:
+//! - `docker` or `podman`
+//! - `kind`
+//! - `kubectl`
+//!
+//! It is mainly intended for automated k8s integration tests.
+
+pub mod infrastructure;
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+use thiserror::Error as ThisError;
+use tracing::error;
+
+use crate::infrastructure::KindClusterError;
+use crate::infrastructure::KustomizeError;
+
+/// Result typed used within the crate.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Errors for the [`kind_k8s`](`crate`) crate.
+///
+/// The error type is used in functions that return a `Result`.
+///
+/// It is structured to identify the sources and to allowing matching on the according error types.
+#[derive(ThisError, Debug)]
+pub enum Error {
+    /// Error originating from an action related to `KustomizeDeployments`
+    #[error(transparent)]
+    Kustomize(#[from] KustomizeError),
+    /// Error originating from an action related to a `KindCluster`
+    #[error(transparent)]
+    Kind(#[from] KindClusterError),
+    /// Error signaling an issue with the cargo workspace directory.
+    #[error("Could not load CARGO_MANIFEST_DIR from environment")]
+    MissingCargoManifestDir,
+    /// Error signaling a missing path.
+    #[error("Path {0} does not existing.")]
+    PathDoesNotExist(PathBuf),
+    /// Error originating from an IO operation.
+    #[error("IO issue {0:?}")]
+    IO(#[from] std::io::Error),
+}
+
+/// Verify if a `Path` exists and is accessible.
+pub fn verify_path<T: AsRef<Path>>(path: T) -> Result<PathBuf> {
+    match path.as_ref().try_exists()? {
+        true => Ok(path.as_ref().to_owned()),
+        false => Err(Error::PathDoesNotExist(path.as_ref().to_owned())),
+    }
+}
+
+/// Get the top level cargo workspace directory from the `CARGO_MANIFEST_DIR`
+/// and a `subdir` suffix that is stripped from the `CARGO_MANIFEST_DIR`.
+///
+/// Required to mount the workspace directory into the containers during build.
+/// Allows accessing files in the workspace (e.g. the pre-built target/ folder for develop images).
+pub fn cargo_workspace_dir(subdir: &str) -> Result<String> {
+    let Some(workspace_dir) = env::var("CARGO_MANIFEST_DIR").ok() else {
+        return Err(Error::MissingCargoManifestDir);
+    };
+
+    let Some(workspace_dir) = workspace_dir.strip_suffix(subdir) else {
+        error!("Could not remove subdirectory {subdir} from CARGO_MANIFEST_DIR {workspace_dir}");
+        return Err(Error::MissingCargoManifestDir);
+    };
+
+    verify_path(workspace_dir)?;
+    Ok(workspace_dir.to_string())
+}

--- a/tests-integration/tests/clusters.rs
+++ b/tests-integration/tests/clusters.rs
@@ -1,0 +1,136 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+use std::env;
+use std::net::ToSocketAddrs;
+use std::time::Duration;
+
+use k8s_openapi::api::apps::v1::Deployment;
+use kube::Api;
+use tests_integration::Result;
+use tests_integration::infrastructure::{
+    ContainerState, ImageTag, KindCluster, KustomizeDeployments, NamespacedName, Workload,
+    WorkloadImageTag,
+};
+use tracing::log::warn;
+use tracing_subscriber::EnvFilter;
+
+async fn create_cluster() -> Result<KindCluster> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_file(true)
+        .with_line_number(true)
+        .init();
+
+    let cluster = KindCluster::new("blixt-tests-integration")?;
+    cluster.create().await?;
+
+    let tag = env::var("TAG").unwrap_or("integration-tests".to_string());
+    let registry = env::var("REGISTRY").unwrap_or("ghcr.io/kubernetes-sigs".to_string());
+    let controlplane_image =
+        env::var("BLIXT_CONTROLPLANE_IMAGE").unwrap_or(format!("{registry}/blixt-controlplane"));
+    let dataplane_image =
+        env::var("BLIXT_DATAPLANE_IMAGE").unwrap_or(format!("{registry}/blixt-dataplane"));
+    let udp_server_image =
+        env::var("BLIXT_UDP_SERVER_IMAGE").unwrap_or(format!("{registry}/blixt-udp-test-server"));
+
+    cluster.load_image(&controlplane_image, &tag).await?;
+    cluster.load_image(&dataplane_image, &tag).await?;
+    cluster.load_image(&udp_server_image, &tag).await?;
+
+    let gateway_api_metallb = vec![
+        "https://github.com/metallb/metallb/config/native?ref=v0.15.2",
+        "https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.3.0",
+    ];
+
+    let deployments = KustomizeDeployments::new(cluster.clone(), gateway_api_metallb).await?;
+    deployments.apply().await?;
+
+    cluster
+        .rollout_status(
+            Workload::Deployment(NamespacedName {
+                name: "controller".to_string(),
+                namespace: "metallb-system".to_string(),
+            }),
+            Duration::from_secs(60),
+        )
+        .await?;
+
+    let deployments = vec!["../config/tests/metallb/", "../config/default/"];
+    let deployments = KustomizeDeployments::new(cluster.clone(), deployments).await?;
+    deployments.apply().await?;
+
+    // patches the workload images and runs a rollout restart & status
+    // this is the first time the containers launch, as the default deployment is on "latest" tag
+    cluster
+        .rollouts(
+            &[
+                WorkloadImageTag {
+                    id: Workload::DaemonSet(NamespacedName {
+                        namespace: "blixt-system".to_string(),
+                        name: "blixt-dataplane".to_string(),
+                    }),
+                    image_tag: Some(ImageTag {
+                        image: dataplane_image,
+                        tag: tag.clone(),
+                    }),
+                },
+                WorkloadImageTag {
+                    id: Workload::Deployment(NamespacedName {
+                        namespace: "blixt-system".to_string(),
+                        name: "blixt-controlplane".to_string(),
+                    }),
+                    image_tag: Some(ImageTag {
+                        image: controlplane_image.clone(),
+                        tag: tag.clone(),
+                    }),
+                },
+            ],
+            Some(Duration::from_secs(60)),
+        )
+        .await?;
+
+    // test k8s client connection
+    let blixt_namespace = "blixt-system";
+    let controlplane_deployment = "blixt-controlplane";
+
+    let k8s_client = cluster.k8s_client().await?;
+    let deployment_api: Api<Deployment> = Api::namespaced(k8s_client, blixt_namespace);
+    let controlplane_deployment = deployment_api.get(controlplane_deployment).await;
+    assert!(controlplane_deployment.is_ok());
+
+    // check if image tag on deployment is correct
+    let deployment = controlplane_deployment.unwrap();
+    let spec = deployment.spec.unwrap();
+    let pod = spec.template.spec.unwrap();
+    assert!(
+        pod.containers
+            .iter()
+            .any(|c| if let Some(image) = &c.image {
+                return image == &format!("{controlplane_image}:{tag}");
+            } else {
+                false
+            })
+    );
+
+    Ok(cluster)
+}
+
+#[tokio::test]
+async fn cluster_test() -> Result<()> {
+    let cluster = create_cluster().await?;
+    cluster.delete().await?;
+    Ok(())
+}


### PR DESCRIPTION
Hello,

this PR contains a first TCPRoute (#336) implementation including an end-to-end integration test.

The test infrastructure was based around:
- command executions `kind`, `kubectl` and `podman`
- executions are abstracted through structs like `KindCluster`, ` Image`, `Container` and `KustomizeDeployments`

The integration test can be executed with:
`cargo test --test integration_tcp_route --profile test`

The test does not install any of the required commands.

I've re-factored/consolidated existing files and tried to find a structure that is suitable, but I'm not sure if the result is the best approach for all the requirements in this project.

Along within the PR are structured error handling and some documentation/overviews.

Many thanks in advance and have a great time. :sunflower: 

Kind regards,
Harald