### PR TITLE
fix(dataplane): aya logging panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ version = "0.3.0"
 
 [workspace.dependencies]
 anyhow = { version = "1", default-features = true }
+# WARN: aya versions need to match with versions in dataplane/ebpf/Cargo.toml which is not a workspace member
+aya = { version = "0.13.1" }
+aya-log = { version = "0.2.1" }
 chrono = { version = "0.4.41", default-features = false }
 clap = { version = "4.5", default-features = true }
 env_logger = { version = "0.11", default-features = false }

--- a/dataplane/api-server/Cargo.toml
+++ b/dataplane/api-server/Cargo.toml
@@ -7,7 +7,7 @@ version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-aya = { version = "0.13.1", features = ["async_tokio"] }
+aya = { workspace = true, features = ["async_tokio"] }
 clap = { workspace = true, features = ["derive"] }
 common = { path = "../common", features = ["user"] }
 libc = { workspace = true }

--- a/dataplane/common/Cargo.toml
+++ b/dataplane/common/Cargo.toml
@@ -14,4 +14,4 @@ default = []
 user = [ "aya" ]
 
 [dependencies]
-aya = { version = "0.13.1", optional=true }
+aya = { workspace = true, optional = true }

--- a/dataplane/ebpf/Cargo.toml
+++ b/dataplane/ebpf/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya-ebpf = { git = "https://github.com/aya-rs/aya" }
-aya-log-ebpf = { git = "https://github.com/aya-rs/aya" }
-aya-ebpf-cty = { git = "https://github.com/aya-rs/aya" }
+aya-ebpf = { version = "0.1.1" }
+aya-log-ebpf = { version = "0.1.1" }
+aya-ebpf-cty = { version = "0.2.2" }
 common = { path = "../common" }
 memoffset = "0.9"
 network-types = "0.0.5"

--- a/dataplane/loader/Cargo.toml
+++ b/dataplane/loader/Cargo.toml
@@ -10,8 +10,8 @@ name = "loader"
 path = "src/main.rs"
 
 [dependencies]
-aya = { version = "0.13.1" , features=["async_tokio"] }
-aya-log = { version = "0.2.1" }
+aya = { workspace = true, features = ["async_tokio"] }
+aya-log = { workspace = true }
 anyhow = { workspace = true }
 api-server = { path = "../api-server" }
 common = { path = "../common", features = ["user"] }


### PR DESCRIPTION
- source all aya versions from workspace (except ebpf)
- sync versions with ebpf

dataplane log output for TCP packet:
```
[DEBUG h2::codec::framed_read] received frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) }
[DEBUG h2::codec::framed_read] received frame=Data { stream_id: StreamId(1), flags: (0x1: END_STREAM) }
[DEBUG h2::codec::framed_write] send frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) }
[DEBUG h2::codec::framed_write] send frame=Data { stream_id: StreamId(1) }
[DEBUG h2::codec::framed_write] send frame=Headers { stream_id: StreamId(1), flags: (0x5: END_HEADERS | END_STREAM) }
[DEBUG h2::codec::framed_read] received frame=WindowUpdate { stream_id: StreamId(0), size_increment: 7 }
[DEBUG h2::codec::framed_read] received frame=Ping { ack: false, payload: [2, 4, 16, 16, 9, 14, 7, 7] }
[DEBUG h2::codec::framed_write] send frame=Ping { ack: true, payload: [2, 4, 16, 16, 9, 14, 7, 7] }
[DEBUG h2::codec::framed_read] received frame=GoAway { error_code: NO_ERROR, last_stream_id: StreamId(1), debug_data: b"client transport shutdown" }
[DEBUG loader::ingress::tcp] Destination backend index: 0
[DEBUG loader::ingress::tcp] Backends length: 1
[INFO  loader::ingress::tcp] Received a TCP packet destined for svc ip: 10.89.0.2 at Port: 8080
[INFO  loader::ingress::tcp] redirect action: 7
[INFO  loader::egress::tcp] Received TCP packet destined for tracked IP 10.89.0.1:39704 setting source IP to VIP 10.89.0.2:8080
[DEBUG loader::ingress::tcp] Destination backend index: 0
[DEBUG loader::ingress::tcp] Backends length: 1
[INFO  loader::ingress::tcp] Received a TCP packet destined for svc ip: 10.89.0.2 at Port: 8080
[INFO  loader::ingress::tcp] redirect action: 7
```

fixes #425 