### PR TITLE
feat(build): enhance container build times

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,28 +58,42 @@ jobs:
               - 'build/Containerfile.*'
       - name: Build controlplane Container Image
         if: steps.filter.outputs.sources
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          push: false
-          context: .
-          file: build/Containerfile.controlplane
-          tags: localhost/blixt-controlplane:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+        run: |
+          mkdir -p target/ &&
+          podman build \
+            --userns=host \
+            --file build/Containerfile.controlplane \
+            --volume "$(pwd):/workspace" \
+            --volume "$(pwd)/target:$(pwd)/target/" \
+            --build-arg BUILD_TIMESTAMP="$(date +%s%3N)" \
+            --build-arg UID="0" \
+            --build-arg GID="0" \
+            --build-arg WORK_DIR="$(pwd)" \
+            --tag localhost/blixt-controlplane:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
       - name: Build dataplane Container Image
-        if: steps.filter.outputs.sources
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          push: false
-          context: .
-          file: build/Containerfile.dataplane
-          tags: localhost/blixt-dataplane:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+        run: |
+          podman build \
+            --userns=host \
+            --file build/Containerfile.dataplane \
+            --volume "$(pwd):/workspace" \
+            --volume "$(pwd)/target:$(pwd)/target/" \
+            --build-arg BUILD_TIMESTAMP="$(date +%s%3N)" \
+            --build-arg UID="0" \
+            --build-arg GID="0" \
+            --build-arg WORK_DIR="$(pwd)" \
+            --tag localhost/blixt-dataplane:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
       - name: Build udp-test-server Container Image
-        if: steps.filter.outputs.sources
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          push: false
-          context: .
-          file: build/Containerfile.udp-test-server
-          tags: localhost/blixt-udp-test-server:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+        run: |
+          podman build \
+            --userns=host \
+            --file build/Containerfile.udp-test-server \
+            --volume "$(pwd):/workspace" \
+            --volume "$(pwd)/target:$(pwd)/target/" \
+            --build-arg BUILD_TIMESTAMP="$(date +%s%3N)" \
+            --build-arg UID="0" \
+            --build-arg GID="0" \
+            --build-arg WORK_DIR="$(pwd)" \
+            --tag localhost/blixt-udp-test-server:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
       - name: Install kind and kubectl
         uses: helm/kind-action@b72c923563e6e80ea66e8e8c810798cc73e97e5e # current main, includes cloud-provider-kind support
         if: steps.filter.outputs.sources
@@ -95,6 +109,8 @@ jobs:
       - name: Run Integration Tests
         if: steps.filter.outputs.sources
         run: |
+          # kind load broken for podman https://github.com/kubernetes-sigs/kind/issues/3945
           export REGISTRY="localhost"
           export TAG="pr-${{ github.event.pull_request.number }}-${{ github.sha }}"
-          make test.integration
+          sudo chown -R "$(id -u):$(id -g)" target/
+          make test.integration.reuse

--- a/build/Containerfile.controlplane
+++ b/build/Containerfile.controlplane
@@ -2,35 +2,52 @@
 # Builder
 # ------------------------------------------------------------------------------
 
-FROM rust:alpine AS builder
+FROM debian:trixie-slim AS builder
 
-RUN apk add --no-cache clang lld
+RUN apt update \
+    && apt install -y build-essential rustup
 
-WORKDIR /workspace
+ARG UID
+ARG GID
+ARG WORK_DIR
+RUN chown "${UID}:${GID}" ${WORK_DIR}
+USER ${UID}:${GID}
 
-ARG PROJECT_DIR=/workspace
+ENV RUSTUP_HOME=${WORK_DIR}/target
+# allow re-using of cargo downloads trough saving in target/
+ENV CARGO_HOME=${WORK_DIR}/target
 
-ARG BUILD_DIR=$PROJECT_DIR/build
+RUN rustup install stable \
+    && rustup default stable
 
-COPY Cargo.toml Cargo.lock ./
+ARG BUILD_TIMESTAMP
+WORKDIR ${WORK_DIR}
 
-COPY controlplane/ controlplane/
+# /workspace needs to be volume mounted
+# ${WORK_DIR}/target can be optionally volume mounted
+RUN echo "${BUILD_TIMESTAMP}" \
+    && date +%s \
+    && cp -a /workspace/Cargo.toml \
+    /workspace/Cargo.lock \
+    /workspace/.cargo/ \
+    /workspace/controlplane/ \
+    /workspace/dataplane/ \
+    /workspace/tests-integration/ \
+    /workspace/tools/ \
+    /workspace/xtask/ \
+    ${WORK_DIR}
 
-COPY dataplane/ dataplane/
-
-COPY tests-integration/ tests-integration/
-
-COPY tools/ tools/
-
-COPY xtask/ xtask/
-
-RUN cargo build -p controlplane --target x86_64-unknown-linux-musl
+RUN date +%s \
+    && cargo build --package controlplane \
+    && date +%s \
+    && mkdir -p results/ \
+    && cp target/debug/controller results/
 
 # ------------------------------------------------------------------------------
 # Image
 # ------------------------------------------------------------------------------
 
-FROM alpine:latest
+FROM debian:trixie-slim
 
 LABEL org.opencontainers.image.source=https://github.com/kubernetes-sigs/blixt
 
@@ -38,6 +55,8 @@ WORKDIR /
 
 USER 1000:1000
 
-COPY --from=builder /workspace/target/x86_64-unknown-linux-musl/debug/controller /controller
+ARG WORK_DIR
+
+COPY --from=builder ${WORK_DIR}/results/controller /controller
 
 ENTRYPOINT [ "/controller" ]

--- a/build/Containerfile.dataplane
+++ b/build/Containerfile.dataplane
@@ -2,73 +2,60 @@
 # Builder
 # ------------------------------------------------------------------------------
 
-FROM rust:slim-bookworm AS builder
+FROM debian:trixie-slim AS builder
 
-RUN apt-get update
+RUN apt update \
+    && apt install -y build-essential rustup
 
-RUN apt-get install --yes \
-    build-essential \
-    llvm-19 \
-    protobuf-compiler \
-    pkg-config \
-    musl-tools \
-    clang \
-    wget \
-    lsb-release \
-    software-properties-common \
-    gnupg
+ARG UID
+ARG GID
+ARG WORK_DIR
+RUN chown "${UID}:${GID}" ${WORK_DIR}
+USER ${UID}:${GID}
 
-RUN rustup default stable
+ENV RUSTUP_HOME=${WORK_DIR}/target
+# allow re-using of cargo downloads trough saving in target/
+ENV CARGO_HOME=${WORK_DIR}/target
 
-RUN rustup install nightly
+RUN rustup install stable \
+    && rustup default stable
 
-RUN rustup component add rust-src --toolchain nightly
+RUN rustup install nightly \
+    && rustup component add rust-src --toolchain nightly \
+    && cargo install bpf-linker
 
-RUN cargo install bpf-linker
+ARG BUILD_TIMESTAMP
+WORKDIR ${WORK_DIR}
 
-WORKDIR /workspace
+# /workspace needs to be volume mounted
+# ${WORK_DIR}/target can be optionally volume mounted
+RUN echo "${BUILD_TIMESTAMP}" \
+    && date +%s \
+    && cp -a /workspace/Cargo.toml \
+    /workspace/Cargo.lock \
+    /workspace/.cargo/ \
+    /workspace/controlplane/ \
+    /workspace/dataplane/ \
+    /workspace/tests-integration/ \
+    /workspace/tools/ \
+    /workspace/xtask/ \
+    ${WORK_DIR}
 
-RUN rustup target add x86_64-unknown-linux-musl
-
-ARG PROJECT_DIR=/workspace
-
-ARG BUILD_DIR=$PROJECT_DIR/build
-
-COPY Cargo.toml Cargo.lock ./
-
-COPY controlplane/ controlplane/
-
-COPY dataplane/ dataplane/
-
-COPY tests-integration/ tests-integration/
-
-COPY tools/ tools/
-
-COPY xtask/ xtask/
-
-COPY .cargo/config.toml .cargo/config.toml
-
-# We need to tell bpf-linker where it can find LLVM's shared library file.
-# Ref: https://github.com/aya-rs/rustc-llvm-proxy/blob/cbcb3c6/src/lib.rs#L48
-ENV LD_LIBRARY_PATH="/usr/lib/llvm-19/lib"
-
-ENV CC_x86_64_unknown_linux_musl="/usr/bin/clang"
-
-ENV AR_x86_64_unknown_linux_musl="/usr/lib/llvm-19/bin/llvm-ar"
-
-RUN cargo xtask build-ebpf
-
-RUN RUSTFLAGS=-Ctarget-feature=+crt-static cargo build \
-    --workspace \
-    --exclude ebpf \ 
-    --package loader \
-    --target=x86_64-unknown-linux-musl
+RUN date +%s \
+    && cargo xtask build-ebpf \
+    && date +%s \
+    && cargo build --package loader \
+    && date +%s \
+    && mkdir -p results/ \
+    && cp target/debug/loader results/ \
+    && cp dataplane/LICENSE.BSD-2-Clause results/ \
+    && cp dataplane/LICENSE.GPL-2.0 results/
 
 # ------------------------------------------------------------------------------
 # Image
 # ------------------------------------------------------------------------------
 
-FROM alpine
+FROM debian:trixie-slim
 
 LABEL org.opencontainers.image.source=https://github.com/kubernetes-sigs/blixt
 
@@ -76,10 +63,12 @@ LABEL org.opencontainers.image.licenses=GPL-2.0-only,BSD-2-Clause
 
 WORKDIR /
 
-COPY --from=builder /workspace/target/x86_64-unknown-linux-musl/debug/loader /dataplane
+ARG WORK_DIR
 
-COPY dataplane/LICENSE.GPL-2.0 /LICENSE.GPL-2.0
+COPY --from=builder ${WORK_DIR}/results/LICENSE.BSD-2-Clause /LICENSE.BSD-2-Clause
 
-COPY dataplane/LICENSE.BSD-2-Clause /LICENSE.BSD-2-Clause
+COPY --from=builder ${WORK_DIR}/results/LICENSE.GPL-2.0 /LICENSE.GPL-2.0
+
+COPY --from=builder ${WORK_DIR}/results/loader /dataplane
 
 ENTRYPOINT ["/dataplane"]

--- a/build/Containerfile.udp-test-server
+++ b/build/Containerfile.udp-test-server
@@ -2,35 +2,52 @@
 # Builder
 # ------------------------------------------------------------------------------
 
-FROM rust:alpine AS builder
+FROM debian:trixie-slim AS builder
 
-RUN apk add --no-cache musl-dev clang lld
+RUN apt update \
+    && apt install -y build-essential rustup
 
-WORKDIR /workspace
+ARG UID
+ARG GID
+ARG WORK_DIR
+RUN chown "${UID}:${GID}" ${WORK_DIR}
+USER ${UID}:${GID}
 
-ARG PROJECT_DIR=/workspace
+ENV RUSTUP_HOME=${WORK_DIR}/target
+# allow re-using of cargo downloads trough saving in target/
+ENV CARGO_HOME=${WORK_DIR}/target
 
-ARG BUILD_DIR=$PROJECT_DIR/build
+RUN rustup install stable \
+    && rustup default stable
 
-COPY Cargo.toml Cargo.lock ./
+ARG BUILD_TIMESTAMP
+WORKDIR ${WORK_DIR}
 
-COPY controlplane/ controlplane/
+# /workspace needs to be volume mounted
+# ${WORK_DIR}/target can be optionally volume mounted
+RUN echo "${BUILD_TIMESTAMP}" \
+    && date +%s \
+    && cp -a /workspace/Cargo.toml \
+    /workspace/Cargo.lock \
+    /workspace/.cargo/ \
+    /workspace/controlplane/ \
+    /workspace/dataplane/ \
+    /workspace/tests-integration/ \
+    /workspace/tools/ \
+    /workspace/xtask/ \
+    ${WORK_DIR}
 
-COPY dataplane/ dataplane/
-
-COPY tests-integration/ tests-integration/
-
-COPY tools/ tools/
-
-COPY xtask/ xtask/
-
-RUN cargo build -p udp-test-server --target x86_64-unknown-linux-musl
+RUN date +%s \
+    && cargo build --package udp-test-server \
+    && date +%s \
+    && mkdir -p results/ \
+    && cp target/debug/udp-test-server results/
 
 # ------------------------------------------------------------------------------
 # Image
 # ------------------------------------------------------------------------------
 
-FROM alpine
+FROM debian:trixie-slim
 
 LABEL org.opencontainers.image.source=https://github.com/kubernetes-sigs/blixt
 
@@ -38,7 +55,9 @@ WORKDIR /
 
 USER 1000:1000
 
-COPY --from=builder /workspace/target/x86_64-unknown-linux-musl/debug/udp-test-server /udp-test-server
+ARG WORK_DIR
+
+COPY --from=builder ${WORK_DIR}/results/udp-test-server /udp-test-server
 
 EXPOSE 9875
 


### PR DESCRIPTION
This draft pr is intended to further discussing #424. It only comprises the build for controlplane and provides a draft layout that could be enrolled to other containers.

- based on Debian trixie slim
- using rustup via apt to install stable rust
- separated build and runtime container
   - runtime container based on plain debian-slim (including apt, shell, ...)
- requires a workspace volume mount
   - optionally supports a workspace/target volume mount to enable re-using of compiled elements
   - in case not mounted a full fledged build is executed
- all source code artefacts required for the build are copied into the container
  - this is currently the most time intense operation during re-usage of pre-compiled elements
- CARGO_HOME is redefined to save downloaded dependencies into target/

```
$ time docker build -f build/Containerfile.controlplane -v "$(pwd):/workspace" -v "$(pwd)/target:/build/target/" --build-arg BUILD_TIMESTAMP=$(date +%s%3N)
[1/2] STEP 1/7: FROM debian:trixie-slim AS builder
[1/2] STEP 2/7: RUN apt update     && apt install -y build-essential rustup     && rustup install stable
--> Using cache 5dc77c2dd41693beebc66a306cf73312f5c9355dfcca1bbfdfa45a960c03b7e1
--> 5dc77c2dd416
[1/2] STEP 3/7: ARG BUILD_TIMESTAMP
--> Using cache 52db6776fc06faad520ef09bb1bdeb59125489af46afc0c35c6c9c7977e61eee
--> 52db6776fc06
[1/2] STEP 4/7: WORKDIR /build
--> Using cache 2862ae0bb1b14024eebbda34b432496c94bbe41a359932b351f0a4bd0470d514
--> 2862ae0bb1b1
[1/2] STEP 5/7: ENV CARGO_HOME=/build/target
--> Using cache 61f2d25c7adb3077b1b50f68ea3cf38a031cb31f17672f3257143f5dbc7f28b6
--> 61f2d25c7adb
[1/2] STEP 6/7: RUN echo "${BUILD_TIMESTAMP}"     && date +%s     && cp -a /workspace/Cargo.toml     /workspace/Cargo.lock     /workspace/controlplane/     /workspace/dataplane/     /workspace/tests-integration/     /workspace/tools/     /workspace/xtask/     /build
1755529247016
1755529248
--> ae88babc1118
[1/2] STEP 7/7: RUN date +%s     && cargo build -p controlplane     && date +%s     && mkdir -p results/     && cp target/debug/controller results/
1755529254
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
1755529254
--> 7452142d2300
[2/2] STEP 1/6: FROM debian:trixie-slim
[2/2] STEP 2/6: LABEL org.opencontainers.image.source=https://github.com/kubernetes-sigs/blixt
--> Using cache fd399516894249f40dc62e585e7f2816bf54cdac0987414cec291507bf59abf7
--> fd3995168942
[2/2] STEP 3/6: WORKDIR /
--> Using cache d63dbdec7772ab7fcd3423962f7bfe8b221a6b81d03236efd9307c3424607143
--> d63dbdec7772
[2/2] STEP 4/6: COPY --from=builder /build/results/controller /controller
--> Using cache 41a90ea11d0b008100a60b8c6aff04c335414efb09322e3f51bc4122bd8f45fd
--> 41a90ea11d0b
[2/2] STEP 5/6: USER 1000:1000
--> Using cache e7d41a49b6da537fa698e3ddc31a8ebaa41c2a6f12c7719d99219e9c80e128b0
--> e7d41a49b6da
[2/2] STEP 6/6: ENTRYPOINT [ "/controller" ]
--> Using cache a21a4a52596ea6a6adfa0c1e8731a73f83a882d46d1d4ffbe5d38e7dbf6342d7
--> a21a4a52596e
a21a4a52596ea6a6adfa0c1e8731a73f83a882d46d1d4ffbe5d38e7dbf6342d7

real    0m14.483s
user    0m1.076s
sys     0m0.129s
$ 
```

fixes: #424 